### PR TITLE
Fix filter not highlighting first slot of any bag

### DIFF
--- a/InventorySearchBar/Inventories/Inventory.cs
+++ b/InventorySearchBar/Inventories/Inventory.cs
@@ -4,6 +4,7 @@ using InventorySearchBar.Filters;
 using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace InventorySearchBar.Inventories
 {
@@ -51,7 +52,7 @@ namespace InventorySearchBar.Inventories
                 return;
             }
 
-            _filter = new List<List<bool>>(_emptyFilter);
+            _filter = new List<List<bool>>(_emptyFilter.Select(bs => new List<bool>(bs)));
             string[] searchTerms = text.ToUpper().Split(Plugin.Settings.SearchTermsSeparatorCharacter);
 
             // get items
@@ -105,7 +106,8 @@ namespace InventorySearchBar.Inventories
 
         protected virtual List<InventoryItem> GetSortedItems()
         {
-            return Plugin.InventoryMonitor.GetSpecificInventory(CharacterId, Category);
+            return Plugin.InventoryMonitor.GetSpecificInventory(CharacterId, Category)
+                .Where(item => item.ItemId != 0).ToList();
         }
 
         protected virtual int ContainerIndex(InventoryItem item)


### PR DESCRIPTION
This PR fixes a bug where the first slot of any bag is never highlighted even when the filters match.

InventoryMonitor.GetSpecificInventory always returns an element for each slot in the bags, rather one for each item occupying a slot. For elements that do not correspond to an item, the element's `SortedSlotIndex` is set to coincide with the first slot of a bag. This causes the phantom elements to override the first slot with highlight=false.

This PR fixes the bug by filtering out phantom items. But in doing so reveals another bug where the template `_emptyFilter` is being modified because copies are made using shallow copy rather than deep copy. This causes slots to not be un-highlighted when a highlighted item is moved to a different slot because the _filter list is never cleared. This only becomes an issue now because the phantom items are no longer iterated over which was the mechanism responsible for unsetting elements in the _filter list previously.